### PR TITLE
Fix bug in LineExtractor.cpp

### DIFF
--- a/src/LineExtractor.cpp
+++ b/src/LineExtractor.cpp
@@ -60,6 +60,8 @@ void LINEextractor::operator()( cv::InputArray _image, cv::InputArray _mask, std
             }
         }
     }
+    else
+        index--;
 
     _keylines.resize(index + 1);
     for(unsigned int i=0; i<index + 1; i++){


### PR DESCRIPTION
At line 55 of the original LineExtractor.cpp, if the IF STATEMENT expression here is FALSE, after skipping the IF STATEMENT, the INDEX in the following "_keylines.resize(index + 1);" statement is the length of _KEYLINES, At this time, if it is resized to INDEX+1 (that is, "length plus one"), the attribute in the added data will be a random value, which will lead to the following "lbd->compute(image, _keylines, descriptors); "statement (Calculate the descriptor of the feature line segment) Infinite loop or error!